### PR TITLE
This should update this theme to the newest version. 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,17 +6,17 @@ plugins {
     // Java support
     id("java")
     // Kotlin support
-    id("org.jetbrains.kotlin.jvm") version "1.6.0"
+    id("org.jetbrains.kotlin.jvm") version "1.7.10"
     // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
-    id("org.jetbrains.intellij") version "1.5.3"
+    id("org.jetbrains.intellij") version "1.8.0"
     // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
     id("org.jetbrains.changelog") version "1.3.1"
     // detekt linter - read more: https://detekt.github.io/detekt/gradle.html
-    id("io.gitlab.arturbosch.detekt") version "1.20.0"
+    id("io.gitlab.arturbosch.detekt") version "1.21.0"
     // ktlint linter - read more: https://github.com/JLLeitschuh/ktlint-gradle
-    id("org.jlleitschuh.gradle.ktlint") version "10.2.1"
+    id("org.jlleitschuh.gradle.ktlint") version "10.3.0"
     // dependency checker
-    id("com.github.ben-manes.versions") version "0.36.0"
+    id("com.github.ben-manes.versions") version "0.42.0"
 }
 
 // Import variables from gradle.properties file

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,16 +3,16 @@
 
 pluginGroup = dev.lankydan.fairyfloss
 pluginName_ = fairyfloss-intellij-theme
-pluginVersion = 0.0.5
+pluginVersion = 0.0.6
 pluginSinceBuild = 193
-pluginUntilBuild = 221.*
+pluginUntilBuild = 222.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
 # pluginVerifierIdeVersions = 2019.3.5, 2020.1.4, 2020.2.3, 2020.3
-pluginVerifierIdeVersions = 2019.3.5, 2020.1.4, 2020.2.3, 2021.1.1, 2022.1
+pluginVerifierIdeVersions = 2019.3.5, 2020.1.4, 2020.2.3, 2021.1.1, 2022.1, 2022.2
 
 platformType = IC
-platformVersion = 2022.1
+platformVersion = 2022.2
 platformDownloadSources = true
 # Plugin Dependencies -> https://www.jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22


### PR DESCRIPTION
I have been wanting to give this theme a try. These should be the necessary changes that is needed to add compatibility with the newest versions of the JetBrains software line.

Within build.gradle.kts the following variables were adjusted:
```
"1.6.0" => id ("org.jetbrains.kotlin.jvm") version "1.7.10"
"1.5.3" => id ("org.jetbrains.intellij") version "1.8.0"
"1.20.0" => id ("io.gitlab.arturbosch.detekt") version "1.21.0"
"10.2.1" => id("org.jlleitschuh.gradle.ktlint") version "10.3.0"
'0.36.0" => id("com.github.ben-manes.versions") version "0.42.0"
```

Within gradle.properties the following variables were adjusted:
```
pluginVersion = 0.0.5 => 0.0.6
pluginUntilBuild = 221.*  => 222.*
pluginVerifierIdeVersions: appended 2022.2
platformVersion = 2022.1 => 2022.2
```