### PR TITLE
Update to 2024.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,15 +3,15 @@
 
 pluginGroup = dev.lankydan.fairyfloss
 pluginName_ = fairyfloss-intellij-theme
-pluginVersion = 1.0.2
+pluginVersion = 1.0.3
 pluginSinceBuild = 193
-pluginUntilBuild = 233.*
+pluginUntilBuild = 242.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2022.2, 2022.3, 2023.1.1, 2023.3
+pluginVerifierIdeVersions = 2022.2, 2022.3, 2023.1.1, 2023.3, 2024.1
 
 platformType = IC
-platformVersion = 2023.3
+platformVersion = 2024.1
 platformDownloadSources = true
 # Plugin Dependencies -> https://www.jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22


### PR DESCRIPTION
Hello! 

This is my favorite theme, THANK YOU for maintaining it!

I recently updated my IDE to the latest version and saw this theme no longer worked with it. I think this patch should get it back up to the current version :)

Some notes:
- I just tweaked the version numbers, changes seem in line w/ past commits to bump versions
- I bumped the `pluginUntilBuild` up to 242.* because [the latest current build](https://www.jetbrains.com/idea/download/other.html) is:
```
Version: 2024.1.2 
Build: 241.17011.79
Released: 23 May 2024
```
I wasn't sure if I should read "Until" in `pluginUntilBuild` as "up to and including" or just "up to", but when I tried building & installing locally it worked for 242 but not 241, so that's what I went with here
- I ran `./gradlew build` and then tried installing it locally to verify it worked, and it did, hooray. Screenshot attached
- I also ran `./gradlew test` and there are some warnings that look like linter warnings from jvm version complaints, but I think that's unrelated to the version bump

<img width="492" alt="image" src="https://github.com/lankydan/fairyfloss-intellij-theme/assets/4534857/3587dd8b-e6a7-4c95-a232-72cbf01ef91e">
<img width="281" alt="image" src="https://github.com/lankydan/fairyfloss-intellij-theme/assets/4534857/01e4cee0-af24-4fb2-af39-71863d31e0e0">
